### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,11 @@ jobs:
     steps:
       - checkout
       - run: |
+          # ktwl41 is part of kelvintay-cci/chef GitHub team
+          # ktwl41 is also following the kelvintaywl-cci/spoon-and-fork original repo
+          echo "this should run!"
+          
+      - run: |
           # check out the org context!
           # should print 'spoon'
           printenv FORK
@@ -17,5 +22,5 @@ workflows:
     jobs:
       - checkout-org-context:
           context:
-            # this org context is available for ALL_MEMBERS of kelvintaywl-cci
+            # this org context is available for kelvintaywl-cci/chef team
             - spoon-and-fork

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,11 @@ jobs:
     steps:
       - checkout
       - run: |
-          # ktwl41 is part of kelvintay-cci/chef GitHub team
-          # ktwl41 is also following the kelvintaywl-cci/spoon-and-fork original repo
-          echo "this should run!"
+          # ktwl41 is no longer part of kelvintay-cci/chef GitHub team
+          # but ktwl41 is also following the kelvintaywl-cci/spoon-and-fork original repo
+          # GitHub reported the team member removal can take 24 hrs to take effect though
+          # Refreshed ktwl41 permissions on CircleCI just in case.
+          echo "this should not run!"
           
       - run: |
           # check out the org context!


### PR DESCRIPTION

observations:

the 1st commit ran as expected since:

- ktwl41 is following the original repo (project) on CircleCI
- ktwl41 is(was) part of the kelvintaywl-cci/chef team that has access to the org context required

I then removed ktwl41 from the team, and expected the 2nd commit not to trigger.

it did trigger, though nothing is built of course, due to unauthorized context.
<img width="429" alt="Screen Shot 2022-09-07 at 14 29 56" src="https://user-images.githubusercontent.com/91649593/188796185-4db202e0-8e37-4ad2-bc73-1c226947b861.png">
